### PR TITLE
Fixed any type issue with n and the operand type issue.

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,10 +1,12 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
-  if (n < 0) {
+export default function fibonacci(n: number): number {
+  if (n < 0){
     return -1;
-  } else if (n == 0) {
+  }
+  else if (n === 0) {
     return 0;
-  } else if (n == 1) {
+  }
+  else if (n === 1){
     return 1;
   }
 


### PR DESCRIPTION
Fixed by giving parameter an explicit type and changed. Recursive calls now return number instead of any.
+ between two numbers is valid → no more operand error.
Testing using actions and testing script in github.